### PR TITLE
Handle legacy Word uploads in ingest service

### DIFF
--- a/app/storage/docx_pdf.py
+++ b/app/storage/docx_pdf.py
@@ -6,15 +6,16 @@ from pathlib import Path
 
 def docx_to_pdf(input_path: str) -> str:
     """
-    将 .docx 转为 .pdf，返回生成的 PDF 路径。
+    将 .doc/.docx 转为 .pdf，返回生成的 PDF 路径。
     - 优先使用 docx2pdf（Windows 下依赖已安装的 MS Word）
     - 失败则抛异常（后续你需要备用方案可再加）
     """
     from docx2pdf import convert  # 延迟导入，避免非 Windows 环境报错
 
     input_path = str(Path(input_path).resolve())
-    if not input_path.lower().endswith(".docx"):
-        raise ValueError("docx_to_pdf only accepts .docx")
+    lower_input = input_path.lower()
+    if not (lower_input.endswith(".docx") or lower_input.endswith(".doc")):
+        raise ValueError("docx_to_pdf only accepts .docx/.doc")
 
     tmpdir = tempfile.mkdtemp(prefix="docx2pdf_")
     out_pdf = str(Path(tmpdir) / (Path(input_path).stem + ".pdf"))

--- a/app/storage/files.py
+++ b/app/storage/files.py
@@ -16,7 +16,7 @@ def guess_file_type(filename: str, mime: str | None) -> FileType:
     name = (filename or "").lower()
     if name.endswith(".pdf"):
         return FileType.pdf_text
-    if name.endswith(".docx"):
+    if name.endswith(".docx") or name.endswith(".doc"):
         return FileType.docx
     if name.endswith(".xlsx"):
         return FileType.xlsx


### PR DESCRIPTION
## Summary
- allow `.doc` uploads to be treated as Word documents during file type detection
- permit the DOC/DOCX to PDF conversion helper to accept legacy `.doc` files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5698fe674832dbdd8134026f84ce4